### PR TITLE
chore: update imports to joint-plus signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ testem.log
 .DS_Store
 Thumbs.db
 
-# rappid
-rappid.tgz
+# joint-plus
+joint-plus.tgz

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This git repository is intended for instructional purposes. It is the source code that accompanies a JointJS+ blog post "Integration with Angular" which can be found [here](https://resources.jointjs.com/tutorial/angular).
 
-### Prerequisites  
+### Prerequisites
 
-To run the following code, you will need a [JointJS+ license](https://www.jointjs.com/license) that comes with the JointJS+ installable package file `rappid.tgz`.
+To run the following code, you will need a [JointJS+ license](https://www.jointjs.com/license) that comes with the JointJS+ installable package file `joint-plus.tgz`.
 
 ### Dependencies
 
@@ -27,7 +27,7 @@ Change into the `joint-plus-tutorial-angular` directory.
 cd joint-plus-tutorial-angular
 ```
 
-For this tutorial, you need to place your own `rappid.tgz` file in the root directory.
+For this tutorial, you need to place your own `joint-plus.tgz` file in the root directory.
 
 When that is completed, you can install the dependencies.
 

--- a/angular.json
+++ b/angular.json
@@ -89,8 +89,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "main": "src/test.ts",
-            "polyfills": "src/polyfills.ts",
+            "polyfills": ["src/polyfills.ts", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^16.2.6",
     "@angular/platform-browser-dynamic": "^16.2.6",
     "@angular/router": "^16.2.6",
-    "@clientio/rappid": "file:rappid.tgz",
+    "@joint/plus": "file:joint-plus.tgz",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2",
     "zone.js": "~0.13.0"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, OnInit, Component, ElementRef, ViewChild } from '@angular/core';
-import { dia, ui, shapes } from '@clientio/rappid';
+import { dia, ui, shapes } from '@joint/plus';
 
 @Component({
   selector: 'app-root',

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
-@import "~@clientio/rappid/rappid.css";
+@import "~@joint/plus/joint-plus.css";
 
 body {
   height: 100vh;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,7 @@
   "files": [
     "src/main.ts",
     "src/polyfills.ts",
-    "node_modules/@clientio/rappid/index.ts"
+    "node_modules/@joint/plus/index.ts"
   ],
   "include": [
     "src/**/*.d.ts"

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -10,7 +10,7 @@
   "files": [
     "src/test.ts",
     "src/polyfills.ts",
-    "node_modules/@clientio/rappid/index.ts"
+    "node_modules/@joint/plus/index.ts"
   ],
   "include": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
In addition to changing the imports this PR includes a fix so the `npm run test` is runnable.